### PR TITLE
add german translation

### DIFF
--- a/src/main/resources/assets/mctouchbar/lang/de_de.json
+++ b/src/main/resources/assets/mctouchbar/lang/de_de.json
@@ -1,0 +1,25 @@
+{
+  "gui.mctouchbar.options.label": "Touch Bar Optionen",
+  "gui.mctouchbar.options.remove": "Lösche Slots",
+  "gui.mctouchbar.options.scroll_up": "∧",
+  "gui.mctouchbar.options.scroll_down": "∨",
+  "gui.mctouchbar.options.search": "Suche",
+  "gui.mctouchbar.options.empty": "Leer",
+
+  "gui.mctouchbar.options.slot.0": "Slot 1",
+  "gui.mctouchbar.options.slot.1": "Slot 2",
+  "gui.mctouchbar.options.slot.2": "Slot 3",
+  "gui.mctouchbar.options.slot.3": "Slot 4",
+  "gui.mctouchbar.options.slot.4": "Slot 5",
+  "gui.mctouchbar.options.slot.5": "Slot 6",
+  "gui.mctouchbar.options.slot.6": "Slot 7",
+  "gui.mctouchbar.options.slot.7": "Slot 8",
+  "gui.mctouchbar.options.slot.8": "Slot 9",
+
+  "widget.mctouchbar.fps": "FPS-Anzeige",
+  "widget.mctouchbar.facing": "Richtungsanzeige",
+  "widget.mctouchbar.debug": "Debug",
+  "widget.mctouchbar.fov_slider": "Sichtfeldregler",
+  "widget.mctouchbar.fov_display": "Sichtfeldanzeige",
+  "widget.mctouchbar.heading": "Heading Display"
+}


### PR DESCRIPTION
I've added German translations to the mod. I wasn't sure what exactly `Heading Display` stands for. If you could provide a screeny for me to show me in which context it gets displayed I'll change the translation.

I can't actually run the mod as I do not have a mac with touchbar.